### PR TITLE
Add subclassing support

### DIFF
--- a/KissXML/Additions/DDXMLElementAdditions.m
+++ b/KissXML/Additions/DDXMLElementAdditions.m
@@ -3,15 +3,7 @@
 @implementation DDXMLElement (DDAdditions)
 
 + (Class)replacementClassForClass:(Class)currentClass {
-    if ( currentClass == [DDXMLElement class] ) {
-        return [DDXMLElement class];
-    }
-    else if ( currentClass == [DDXMLNode class] ) {
-        return [DDXMLNode class];
-    }
-    else {
-        return [DDXMLDocument class];
-    }
+    return currentClass;
 }
 
 /**

--- a/KissXML/DDXMLDocument.m
+++ b/KissXML/DDXMLDocument.m
@@ -22,15 +22,7 @@
 @implementation DDXMLDocument
 
 + (Class)replacementClassForClass:(Class)currentClass {
-    if ( currentClass == [DDXMLElement class] ) {
-        return [DDXMLElement class];
-    }
-    else if ( currentClass == [DDXMLNode class] ) {
-        return [DDXMLNode class];
-    }
-    else {
-        return [DDXMLDocument class];
-    }
+    return currentClass;
 }
 
 /**

--- a/KissXML/DDXMLElement.m
+++ b/KissXML/DDXMLElement.m
@@ -22,15 +22,7 @@
 @implementation DDXMLElement
 
 + (Class)replacementClassForClass:(Class)currentClass {
-    if ( currentClass == [DDXMLElement class] ) {
-        return [DDXMLElement class];
-    }
-    else if ( currentClass == [DDXMLNode class] ) {
-        return [DDXMLNode class];
-    }
-    else {
-        return [DDXMLDocument class];
-    }
+    return currentClass;
 }
 
 /**

--- a/KissXML/DDXMLNode.m
+++ b/KissXML/DDXMLNode.m
@@ -41,15 +41,7 @@ static void MarkDeath(void *xmlPtr, DDXMLNode *wrapper);
 #endif
 
 + (Class)replacementClassForClass:(Class)currentClass {
-    if ( currentClass == [DDXMLElement class] ) {
-        return [DDXMLElement class];
-    }
-    else if ( currentClass == [DDXMLNode class] ) {
-        return [DDXMLNode class];
-    }
-    else {
-        return [DDXMLDocument class];
-    }
+    return currentClass;
 }
 
 /**


### PR DESCRIPTION
Because of the architecture and data model of NSXML, when it parses and processes a source of XML it cannot know about your subclass unless you override the class method replacementClassForClass: to return your custom class in place of an NSXML class.
