### PR TITLE
Implement DDXMLNode nodesForXPath:namespaceMappings:error.

### DIFF
--- a/KissXML/DDXMLNode.h
+++ b/KissXML/DDXMLNode.h
@@ -150,6 +150,11 @@ enum {
 #pragma mark --- XPath/XQuery ---
 
 - (NSArray *)nodesForXPath:(NSString *)xpath error:(NSError **)error;
+
+// This is an extension over NSXMLNode.
+// It is required if you are using XPath with documents with default namespaces.
+- (NSArray *)nodesForXPath:(NSString *)xpath namespaceMappings:(NSDictionary*)namespaceMappings error:(NSError **)error;
+
 //- (NSArray *)objectsForXQuery:(NSString *)xquery constants:(NSDictionary *)constants error:(NSError **)error;
 //- (NSArray *)objectsForXQuery:(NSString *)xquery error:(NSError **)error;
 

--- a/KissXML/DDXMLNode.m
+++ b/KissXML/DDXMLNode.m
@@ -1196,6 +1196,11 @@ static void MarkDeath(void *xmlPtr, DDXMLNode *wrapper);
 
 - (NSArray *)nodesForXPath:(NSString *)xpath error:(NSError **)error
 {
+	return [self nodesForXPath:xpath namespaceMappings:nil error:error];
+}
+
+- (NSArray *)nodesForXPath:(NSString *)xpath namespaceMappings:namespaceMappings error:(NSError **)error
+{
 #if DDXML_DEBUG_MEMORY_ISSUES
 	DDXMLNotZombieAssert();
 #endif
@@ -1230,15 +1235,28 @@ static void MarkDeath(void *xmlPtr, DDXMLNode *wrapper);
 	xpathCtx = xmlXPathNewContext(doc);
 	xpathCtx->node = (xmlNodePtr)genericPtr;
 		
-	xmlNodePtr rootNode = (doc)->children;
-	if(rootNode != NULL)
-	{
-		xmlNsPtr ns = rootNode->nsDef;
-		while(ns != NULL)
+	if (namespaceMappings) {
+		for (NSString* k in namespaceMappings) {
+			NSString* v = [namespaceMappings objectForKey:k];
+			xmlXPathRegisterNs(xpathCtx, [k xmlChar], [v xmlChar]);
+		}
+	}
+	else {
+		xmlNodePtr rootNode = doc->children;
+		if(rootNode != NULL)
 		{
-			xmlXPathRegisterNs(xpathCtx, ns->prefix, ns->href);
-			
-			ns = ns->next;
+			xmlNsPtr ns = rootNode->nsDef;
+			while(ns != NULL)
+			{
+				const xmlChar* prefix = ns->prefix;
+				if (!prefix || !*prefix)
+				{
+					prefix = rootNode->name;
+				}
+				xmlXPathRegisterNs(xpathCtx, prefix, ns->href);
+				
+				ns = ns->next;
+			}
 		}
 	}
 	


### PR DESCRIPTION
This allows the caller to pass in an NSDictionary specifying the mapping
from namespace prefix to namespace URL.  Namespace prefixes specified in
the given XPath will then be resolved against that mapping.

This allows callers to find nodes using default namespaces, e.g.
<element xmlns='<schema URL>'>...</element>.  The caller must specify
prefix=<schema URL> in namespaceMappings, and then can use prefix:element
in the XPath.

If namespaceMappings is nil, then the existing behavior is used
(parsing the namespaces from the document node).  This works in the
situation where the namespaces are all named explicitly, and all on the
root node, but not in general.

This addresses upstream issue #19, the second half of issue #20.
