### PR TITLE
Add a DDXML_NS_DECLARATIONS_ENABLED macro.

### DIFF
--- a/KissXML/DDXML.h
+++ b/KissXML/DDXML.h
@@ -21,8 +21,11 @@
 #import "DDXMLDocument.h"
 
 
+#ifndef DDXML_NS_DECLARATIONS_ENABLED
+#define DDXML_NS_DECLARATIONS_ENABLED 0  // Disabled by default
+#endif
 
-#if TARGET_OS_IPHONE && 0 // Disabled by default
+#if TARGET_OS_IPHONE && DDXML_NS_DECLARATIONS_ENABLED
 
 // Since KissXML is a drop in replacement for NSXML,
 // it may be desireable (when writing cross-platform code to be used on both Mac OS X and iOS)


### PR DESCRIPTION
This allows us to enable the NS* aliases with a preprocessor flag, instead
of having to modify the source code.

This closes upstream issue #15.  The original code was by Robert Payne
(robertjpayne).