### PR TITLE
Fix Xcode compiler warning: Implicit conversion loses integer precision:...

### DIFF
--- a/KissXML/DDXMLDocument.m
+++ b/KissXML/DDXMLDocument.m
@@ -91,7 +91,7 @@
 	// Therefore, we call it again here just to be safe.
 	xmlKeepBlanksDefault(0);
 	
-	xmlDocPtr doc = xmlParseMemory([data bytes], [data length]);
+	xmlDocPtr doc = xmlParseMemory([data bytes], (int)[data length]);
 	if (doc == NULL)
 	{
 		if (error) *error = [NSError errorWithDomain:@"DDXMLErrorDomain" code:1 userInfo:nil];


### PR DESCRIPTION
... 'NSUInteger' (aka 'unsigned long') to 'int'
