### PR TITLE
Add support for CDATA elements.

### DIFF
--- a/KissXML/DDXMLElement.h
+++ b/KissXML/DDXMLElement.h
@@ -26,6 +26,7 @@
 - (id)initWithName:(NSString *)name;
 - (id)initWithName:(NSString *)name URI:(NSString *)URI;
 - (id)initWithName:(NSString *)name stringValue:(NSString *)string;
+- (id)initWithName:(NSString *)name cdata:(NSString *)cdata;
 - (id)initWithXMLString:(NSString *)string error:(NSError **)error;
 
 #pragma mark --- Elements by name ---

--- a/KissXML/DDXMLElement.m
+++ b/KissXML/DDXMLElement.m
@@ -101,6 +101,23 @@
 	return result;
 }
 
+- (id)initWithName:(NSString *)name cdata:(NSString *)cdata
+{
+	xmlNodePtr node = xmlNewNode(NULL, [name xmlChar]);
+	if (node == NULL)
+	{
+		return nil;
+	}
+
+	const char * content = cdata.UTF8String;
+	xmlNodePtr cdataNode = xmlNewCDataBlock(node->doc, BAD_CAST content, (int)strlen(content));
+	xmlAddChild(node, cdataNode);
+
+	DDXMLElement *result = [self initWithElementPrimitive:node owner:nil];
+
+	return result;
+}
+
 - (id)initWithXMLString:(NSString *)string error:(NSError **)error
 {
 	DDXMLDocument *doc = [[DDXMLDocument alloc] initWithXMLString:string options:0 error:error];

--- a/KissXML/DDXMLNode.h
+++ b/KissXML/DDXMLNode.h
@@ -75,6 +75,8 @@ enum {
 
 + (id)elementWithName:(NSString *)name stringValue:(NSString *)string;
 
++ (id)elementWithName:(NSString *)name cdata:(NSString *)cdata;
+
 + (id)elementWithName:(NSString *)name children:(NSArray *)children attributes:(NSArray *)attributes;
 
 + (id)attributeWithName:(NSString *)name stringValue:(NSString *)stringValue;

--- a/KissXML/DDXMLNode.m
+++ b/KissXML/DDXMLNode.m
@@ -88,6 +88,11 @@ static void MarkDeath(void *xmlPtr, DDXMLNode *wrapper);
 	return [[DDXMLElement alloc] initWithName:name stringValue:string];
 }
 
++ (id)elementWithName:(NSString *)name cdata:(NSString *)cdata
+{
+	return [[DDXMLElement alloc] initWithName:name cdata:cdata];
+}
+
 + (id)elementWithName:(NSString *)name children:(NSArray *)children attributes:(NSArray *)attributes
 {
 	DDXMLElement *result = [[DDXMLElement alloc] initWithName:name];


### PR DESCRIPTION
This adds a constructor for DDXMLElement that turns into a call
to xmlNewCDataBlock and adds the CDATA node as a child of the
DDXMLElement node.

This also adds the appropriate helper to DDXMLNode.