### PR TITLE
Add support for import into ios swift file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script:
   - pod install --project-directory=./Tests/Mac --no-repo-update
   - pod install --project-directory=./Tests/iOS --no-repo-update
   - pod install --project-directory=./Tests/Swift --no-repo-update
+  - pod install --project-directory=./Tests/Swift-iOS --no-repo-update
   - xctool -workspace ./Tests/Mac/KissXML.xcworkspace -scheme KissXMLTests -sdk macosx -arch x86_64 test
   - xctool -workspace ./Tests/iOS/KissXML.xcworkspace -scheme KissXMLTests -sdk iphonesimulator -arch i386 test
   - xctool -workspace ./Tests/Swift/KissXML.xcworkspace -scheme KissXMLSwiftTests -sdk macosx -arch x86_64 test
+  - xctool -workspace ./Tests/Swift-iOS/KissXML.xcworkspace -scheme KissXMLSwiftTests -sdk iphonesimulator -arch i386 test

--- a/KissXML.podspec
+++ b/KissXML.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     ss.dependency 'KissXML/Core'
     ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2',
                         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
-                        'OTHER_CFLAGS' => "$(inherited) -DDDXML_NS_DECLARATIONS_ENABLED=1 -DDDXML_LIBXML_MODULE_ENABLED=0"}
+                        'OTHER_CFLAGS' => "$(inherited) -DDDXML_LIBXML_MODULE_ENABLED=0"}
   end
 
   s.subspec 'libxml_module' do |ss|
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
     ss.preserve_path = 'libxml/module.modulemap'
     ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2 $(PODS_ROOT)/KissXML/libxml "$(PODS_ROOT)/../../../libxml"',
                         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'NO',
-                        'OTHER_CFLAGS' => "$(inherited) -DDDXML_NS_DECLARATIONS_ENABLED=1 -DDDXML_LIBXML_MODULE_ENABLED=1",
-                        'OTHER_SWIFT_FLAGS' => "$(inherited) -DDDXML_NS_DECLARATIONS_ENABLED -DDDXML_LIBXML_MODULE_ENABLED"
+                        'OTHER_CFLAGS' => "$(inherited) -DDDXML_LIBXML_MODULE_ENABLED=1",
+                        'OTHER_SWIFT_FLAGS' => "$(inherited) -DDDXML_LIBXML_MODULE_ENABLED"
                       }
   end
 

--- a/KissXML.podspec
+++ b/KissXML.podspec
@@ -25,10 +25,13 @@ Pod::Spec.new do |s|
 
   s.subspec 'libxml_module' do |ss|
     ss.dependency 'KissXML/Core'
+    ss.ios.source_files  = 'KissXML/**/*.swift'
     ss.preserve_path = 'libxml/module.modulemap'
     ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2 $(PODS_ROOT)/KissXML/libxml "$(PODS_ROOT)/../../../libxml"',
                         'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'NO',
-                        'OTHER_CFLAGS' => "$(inherited) -DDDXML_NS_DECLARATIONS_ENABLED=1 -DDDXML_LIBXML_MODULE_ENABLED=1"}
+                        'OTHER_CFLAGS' => "$(inherited) -DDDXML_NS_DECLARATIONS_ENABLED=1 -DDDXML_LIBXML_MODULE_ENABLED=1",
+                        'OTHER_SWIFT_FLAGS' => "$(inherited) -DDDXML_NS_DECLARATIONS_ENABLED -DDDXML_LIBXML_MODULE_ENABLED"
+                      }
   end
 
   s.ios.deployment_target = "6.0"

--- a/KissXML/DDXML.h
+++ b/KissXML/DDXML.h
@@ -1,18 +1,18 @@
 /**
  * Welcome to KissXML.
- * 
+ *
  * The project page has documentation if you have questions.
  * https://github.com/robbiehanson/KissXML
- * 
+ *
  * If you're new to the project you may wish to read the "Getting Started" wiki.
  * https://github.com/robbiehanson/KissXML/wiki/GettingStarted
- * 
+ *
  * KissXML provides a drop-in replacement for Apple's NSXML class cluster.
  * The goal is to get the exact same behavior as the NSXML classes.
- * 
+ *
  * For API Reference, see Apple's excellent documentation,
  * either via Xcode's Mac OS X documentation, or via the web:
- * 
+ *
  * https://github.com/robbiehanson/KissXML/wiki/Reference
 **/
 
@@ -20,17 +20,12 @@
 #import "DDXMLElement.h"
 #import "DDXMLDocument.h"
 
-
-#ifndef DDXML_NS_DECLARATIONS_ENABLED
-#define DDXML_NS_DECLARATIONS_ENABLED 0  // Disabled by default
-#endif
-
-#if TARGET_OS_IPHONE && DDXML_NS_DECLARATIONS_ENABLED
+#if TARGET_OS_IPHONE
 
 // Since KissXML is a drop in replacement for NSXML,
 // it may be desireable (when writing cross-platform code to be used on both Mac OS X and iOS)
 // to use the NSXML prefixes instead of the DDXML prefix.
-// 
+//
 // This way, on Mac OS X it uses NSXML, and on iOS it uses KissXML.
 
 #ifndef NSXMLNode
@@ -102,12 +97,12 @@
 
 // KissXML has rather straight-forward memory management:
 // https://github.com/robbiehanson/KissXML/wiki/MemoryManagementThreadSafety
-// 
+//
 // There are 3 important concepts to keep in mind when working with KissXML:
-// 
-// 
+//
+//
 // 1.) KissXML provides a light-weight wrapper around libxml.
-// 
+//
 // The parsing, creation, storage, etc of the xml tree is all done via libxml.
 // This is a fast low-level C library that's been around for ages, and comes pre-installed on Mac OS X and iOS.
 // KissXML provides an easy-to-use Objective-C library atop libxml.
@@ -118,16 +113,16 @@
 // the library may create multiple DDXML wrapper objects that point to the same underlying xml node.
 // So don't assume you can test for equality with "==".
 // Instead use the isEqual method (as you should generally do with objects anyway).
-// 
-// 
+//
+//
 // 2.) XML is implicitly a tree heirarchy, and the XML API's are designed to allow traversal up & down the tree.
-// 
+//
 // The tree heirarchy and API contract have an implicit impact concerning memory management.
-// 
+//
 // <starbucks>
 //   <latte/>
 // </starbucks>
-// 
+//
 // Imagine you have a DDXMLNode corresponding to the starbucks node,
 // and you have a DDXMLNode corresponding to the latte node.
 // Now imagine you release the starbucks node, but you retain a reference to the latte node.
@@ -136,24 +131,24 @@
 // So if the latte node is still around, the xml tree heirarchy must stick around as well.
 // So even though the DDXMLNode corresponding to the starbucks node may get deallocated,
 // the underlying xml tree structure won't be freed until the latte node gets dealloacated.
-// 
+//
 // In general, this means that KissXML remains thread-safe when reading and processing a tree.
 // If you traverse a tree and fork off asynchronous tasks to process subnodes,
 // the tree will remain properly in place until all your asynchronous tasks have completed.
 // In other words, it just works.
-// 
+//
 // However, if you parse a huge document into memory, and retain a single node from the giant xml tree...
 // Well you should see the problem this creates.
 // Instead, in this situation, copy or detach the node if you want to keep it around.
 // Or just extract the info you need from it.
-// 
-// 
+//
+//
 // 3.) KissXML is read-access thread-safe, but write-access thread-unsafe (designed for speed).
-// 
+//
 // <starbucks>
 //   <latte/>
 // </starbucks>
-// 
+//
 // Imagine you have a DDXMLNode corresponding to the starbucks node,
 // and you have a DDXMLNode corresponding to the latte node.
 // What happens if you invoke [starbucks removeChildAtIndex:0]?
@@ -163,13 +158,13 @@
 // This is pretty obvious when you think about it from the context of this simple example.
 // But in the real world, you might have multiple threads running in parallel,
 // and you might accidently modify a node while another thread is processing it.
-// 
+//
 // To completely fix this problem, and provide write-access thread-safety, would require extensive overhead.
 // This overhead is completely unwanted in the majority of cases.
 // Most XML usage patterns are heavily read-only.
 // And in the case of xml creation or modification, it is generally done on the same thread.
 // Thus the KissXML library is write-access thread-unsafe, but provides speedier performance.
-// 
+//
 // However, when such a bug does creep up, it produces horrible side-effects.
 // Essentially the pointer to the underlying xml structure becomes a dangling pointer,
 // which means that accessing the dangling pointer might give you the correct results, or completely random results.
@@ -179,17 +174,17 @@
 // So to help out, the library provides a debugging macro to track down these problems.
 // That is, if you invalidate the write-access thread-unsafe rule,
 // this macro will tell you when you're trying to access a now-dangling pointer.
-// 
+//
 // How does it work?
 // Well everytime a DDXML wrapper object is created atop a libxml structure,
 // it marks the linkage in a table.
 // And everytime a libxml structure is freed, it destorys all corresponding linkages in the table.
 // So everytime a DDXML wrapper objects is about to dereference it's pointer,
 // it first ensures the linkage still exists in the table.
-// 
+//
 // Set to 1 to enable
 // Set to 0 to disable (this is the default)
-// 
+//
 // The debugging macro adds a significant amount of overhead, and should NOT be enabled on production builds.
 
 #if DEBUG

--- a/KissXML/DDXML.swift
+++ b/KissXML/DDXML.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  KissXML
+//
+//  Created by David Chiles on 1/29/16.
+//
+//
+
+import Foundation
+
+#if os(iOS) && DDXML_NS_DECLARATIONS_ENABLED
+    public typealias  NSXMLNode = DDXMLNode
+    public typealias  NSXMLElement = DDXMLElement
+    public typealias  NSXMLDocument = DDXMLDocument
+    public let  NSXMLInvalidKind = DDXMLInvalidKind
+    public let  NSXMLDocumentKind = DDXMLDocumentKind
+    public let  NSXMLElementKind = DDXMLElementKind
+    public let  NSXMLAttributeKind = DDXMLAttributeKind
+    public let  NSXMLNamespaceKind = DDXMLNamespaceKind
+    public let  NSXMLProcessingInstructionKind = DDXMLProcessingInstructionKind
+    public let  NSXMLCommentKind = DDXMLCommentKind
+    public let  NSXMLTextKind = DDXMLTextKind
+    public let  NSXMLDTDKind = DDXMLDTDKind
+    public let  NSXMLEntityDeclarationKind = DDXMLEntityDeclarationKind
+    public let  NSXMLAttributeDeclarationKind = DDXMLAttributeDeclarationKind
+    public let  NSXMLElementDeclarationKind = DDXMLElementDeclarationKind
+    public let  NSXMLNotationDeclarationKind = DDXMLNotationDeclarationKind
+    public let  NSXMLNodeOptionsNone = DDXMLNodeOptionsNone
+    public let  NSXMLNodeExpandEmptyElement = DDXMLNodeExpandEmptyElement
+    public let  NSXMLNodeCompactEmptyElement = DDXMLNodeCompactEmptyElement
+    public let  NSXMLNodePrettyPrint = DDXMLNodePrettyPrint
+#endif

--- a/KissXML/DDXML.swift
+++ b/KissXML/DDXML.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if os(iOS) && DDXML_NS_DECLARATIONS_ENABLED
+#if os(iOS)
     public typealias  NSXMLNode = DDXMLNode
     public typealias  NSXMLElement = DDXMLElement
     public typealias  NSXMLDocument = DDXMLDocument

--- a/Tests/Swift-iOS/KissXML.xcodeproj/project.pbxproj
+++ b/Tests/Swift-iOS/KissXML.xcodeproj/project.pbxproj
@@ -1,0 +1,330 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		162C7C5010F40EBE8203CDDF /* Pods_KissXMLSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1391D46037D659E4C95661B /* Pods_KissXMLSwiftTests.framework */; };
+		63F8CF211C5C1285000D126C /* KissXMLSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F8CF201C5C1285000D126C /* KissXMLSwiftTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		04BC4818FCD29FA6DB328AE0 /* Pods-KissXMLSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KissXMLSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KissXMLSwiftTests/Pods-KissXMLSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4A364AD556F4AAF956EC51DF /* Pods-KissXMLSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KissXMLSwiftTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KissXMLSwiftTests/Pods-KissXMLSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
+		63F8CF1D1C5C1285000D126C /* KissXMLSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KissXMLSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		63F8CF201C5C1285000D126C /* KissXMLSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KissXMLSwiftTests.swift; sourceTree = "<group>"; };
+		63F8CF221C5C1285000D126C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F1391D46037D659E4C95661B /* Pods_KissXMLSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KissXMLSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		63F8CF1A1C5C1285000D126C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				162C7C5010F40EBE8203CDDF /* Pods_KissXMLSwiftTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		392608F6AC68FFEC11C4C2CE /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				04BC4818FCD29FA6DB328AE0 /* Pods-KissXMLSwiftTests.debug.xcconfig */,
+				4A364AD556F4AAF956EC51DF /* Pods-KissXMLSwiftTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		63F8CF121C5C1250000D126C = {
+			isa = PBXGroup;
+			children = (
+				63F8CF1F1C5C1285000D126C /* KissXMLSwiftTests */,
+				63F8CF1E1C5C1285000D126C /* Products */,
+				392608F6AC68FFEC11C4C2CE /* Pods */,
+				D402F3F38B5C54AB1274F269 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		63F8CF1E1C5C1285000D126C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				63F8CF1D1C5C1285000D126C /* KissXMLSwiftTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		63F8CF1F1C5C1285000D126C /* KissXMLSwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				63F8CF201C5C1285000D126C /* KissXMLSwiftTests.swift */,
+				63F8CF221C5C1285000D126C /* Info.plist */,
+			);
+			path = KissXMLSwiftTests;
+			sourceTree = "<group>";
+		};
+		D402F3F38B5C54AB1274F269 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F1391D46037D659E4C95661B /* Pods_KissXMLSwiftTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		63F8CF1C1C5C1285000D126C /* KissXMLSwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 63F8CF251C5C1285000D126C /* Build configuration list for PBXNativeTarget "KissXMLSwiftTests" */;
+			buildPhases = (
+				A82C0912363DD7E77F2A164C /* Check Pods Manifest.lock */,
+				63F8CF191C5C1285000D126C /* Sources */,
+				63F8CF1A1C5C1285000D126C /* Frameworks */,
+				63F8CF1B1C5C1285000D126C /* Resources */,
+				77E191930F2E3AF3CA36D3AA /* Embed Pods Frameworks */,
+				9E8F15436ED00C0B546A7A6D /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KissXMLSwiftTests;
+			productName = KissXMLSwiftTests;
+			productReference = 63F8CF1D1C5C1285000D126C /* KissXMLSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		63F8CF131C5C1250000D126C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0720;
+				TargetAttributes = {
+					63F8CF1C1C5C1285000D126C = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = 63F8CF161C5C1250000D126C /* Build configuration list for PBXProject "KissXML" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 63F8CF121C5C1250000D126C;
+			productRefGroup = 63F8CF1E1C5C1285000D126C /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				63F8CF1C1C5C1285000D126C /* KissXMLSwiftTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		63F8CF1B1C5C1285000D126C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		77E191930F2E3AF3CA36D3AA /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-KissXMLSwiftTests/Pods-KissXMLSwiftTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9E8F15436ED00C0B546A7A6D /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-KissXMLSwiftTests/Pods-KissXMLSwiftTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A82C0912363DD7E77F2A164C /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		63F8CF191C5C1285000D126C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				63F8CF211C5C1285000D126C /* KissXMLSwiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		63F8CF171C5C1250000D126C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		63F8CF181C5C1250000D126C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		63F8CF231C5C1285000D126C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 04BC4818FCD29FA6DB328AE0 /* Pods-KissXMLSwiftTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = KissXMLSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidchiles.KissXMLSwiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		63F8CF241C5C1285000D126C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A364AD556F4AAF956EC51DF /* Pods-KissXMLSwiftTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = KissXMLSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidchiles.KissXMLSwiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		63F8CF161C5C1250000D126C /* Build configuration list for PBXProject "KissXML" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				63F8CF171C5C1250000D126C /* Debug */,
+				63F8CF181C5C1250000D126C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		63F8CF251C5C1285000D126C /* Build configuration list for PBXNativeTarget "KissXMLSwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				63F8CF231C5C1285000D126C /* Debug */,
+				63F8CF241C5C1285000D126C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 63F8CF131C5C1250000D126C /* Project object */;
+}

--- a/Tests/Swift-iOS/KissXML.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/Swift-iOS/KissXML.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:KissXML.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tests/Swift-iOS/KissXML.xcodeproj/xcshareddata/xcschemes/KissXMLSwiftTests.xcscheme
+++ b/Tests/Swift-iOS/KissXML.xcodeproj/xcshareddata/xcschemes/KissXMLSwiftTests.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63F8CF1C1C5C1285000D126C"
+               BuildableName = "KissXMLSwiftTests.xctest"
+               BlueprintName = "KissXMLSwiftTests"
+               ReferencedContainer = "container:KissXML.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63F8CF1C1C5C1285000D126C"
+               BuildableName = "KissXMLSwiftTests.xctest"
+               BlueprintName = "KissXMLSwiftTests"
+               ReferencedContainer = "container:KissXML.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "63F8CF1C1C5C1285000D126C"
+            BuildableName = "KissXMLSwiftTests.xctest"
+            BlueprintName = "KissXMLSwiftTests"
+            ReferencedContainer = "container:KissXML.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "63F8CF1C1C5C1285000D126C"
+            BuildableName = "KissXMLSwiftTests.xctest"
+            BlueprintName = "KissXMLSwiftTests"
+            ReferencedContainer = "container:KissXML.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Swift-iOS/KissXML.xcworkspace/contents.xcworkspacedata
+++ b/Tests/Swift-iOS/KissXML.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:KissXML.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tests/Swift-iOS/KissXMLSwiftTests/Info.plist
+++ b/Tests/Swift-iOS/KissXMLSwiftTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Tests/Swift-iOS/KissXMLSwiftTests/KissXMLSwiftTests.swift
+++ b/Tests/Swift-iOS/KissXMLSwiftTests/KissXMLSwiftTests.swift
@@ -1,0 +1,29 @@
+//
+//  KissXMLSwiftTests.swift
+//  KissXMLSwiftTests
+//
+//  Created by David Chiles on 1/29/16.
+//
+//
+
+import XCTest
+import KissXML
+
+class KissXMLSwiftTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testElementCreatoin() {
+        let element = NSXMLNode()
+        XCTAssertNotNil(element)
+    }
+    
+}

--- a/Tests/Swift-iOS/Podfile
+++ b/Tests/Swift-iOS/Podfile
@@ -1,0 +1,8 @@
+source 'https://github.com/CocoaPods/Specs.git'
+use_frameworks!
+platform :ios, "8"
+
+
+target 'KissXMLSwiftTests', :exclusive => true do
+  pod "KissXML/libxml_module", :path => "../../"
+end

--- a/Tests/Swift-iOS/Podfile.lock
+++ b/Tests/Swift-iOS/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - KissXML/Core (5.0.2)
+  - KissXML/libxml_module (5.0.2):
+    - KissXML/Core
+
+DEPENDENCIES:
+  - KissXML/libxml_module (from `../../`)
+
+EXTERNAL SOURCES:
+  KissXML:
+    :path: ../../
+
+SPEC CHECKSUMS:
+  KissXML: 2e8ba8c20a552b01c48afe3fc0bb114ed5ac407e
+
+COCOAPODS: 0.39.0


### PR DESCRIPTION
I needed to remove `DDXML_NS_DECLARATIONS_ENABLED` because attempting to use KissXML through XMPPFramework I wasn't able to build from a swift target.

I don't know why. I don't even understand why Xcode would do this to me.