### PR TITLE
Make DDXMLPrivate.h a private header.

### DIFF
--- a/KissXML.podspec
+++ b/KissXML.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'KissXML/**/*.{h,m}'
+    ss.private_header_files = 'KissXML/Private/**/*.h'
     ss.library      = 'xml2'
     ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'}
   end


### PR DESCRIPTION
Removes this header from the umbrella header and fixes issue in Xcode 8 where this header, which imports <libxml/tree.h>, would cause an "Include of non-modular header inside framework module" compile error to be thrown.