### PR TITLE
Fix Carthage build for watchOS and tvOS

### DIFF
--- a/KissXML.xcodeproj/project.pbxproj
+++ b/KissXML.xcodeproj/project.pbxproj
@@ -691,6 +691,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -713,6 +714,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -736,6 +738,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -758,6 +761,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;


### PR DESCRIPTION
Carthage builds currently break on the tvOS and watchOS targets due to an incorrect value for `TARGETED_DEVICE_FAMILY` for these targets.

As per https://github.com/Carthage/Carthage/issues/950#issuecomment-176291457, which outlines the correct values for each platform, this PR updates those values. The builds successfully complete now.

There is an existing PR (https://github.com/robbiehanson/KissXML/pull/90) that covers a portion of these fixes, but it is currently in conflict and doesn't include the watchOS fixes. 