### PR TITLE
Fix Xcode 12 warning IPHONEOS_DEPLOYMENT_TARGET  is set to 8.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "KissXML",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],


### PR DESCRIPTION
Fixes the warning 
`The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.2.99.`
when using Swift Package Manager